### PR TITLE
Apply patch #3101439 to fix a query string undefined offset

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,2 +1,4 @@
 * Issue #2994529 by Olarin, juampynr: Some sites may not want the extra save buttons
   * https://www.drupal.org/project/amp/issues/2994529#comment-12881223
+* Issue #3101439 by joshua.roberson: Query String Undefined Offset
+  * https://www.drupal.org/files/issues/2019-12-16/amp-query-string-undefined-offset-3101439-2.patch

--- a/src/Asset/AmpCssCollectionRenderer.php
+++ b/src/Asset/AmpCssCollectionRenderer.php
@@ -114,7 +114,9 @@ class AmpCssCollectionRenderer extends CssCollectionRenderer {
         }
         else {
           // Strip any querystring off the url.
-          list($url, $query) = explode('?', $url);
+          if (strpos($url, '?') !== FALSE) {
+            list($url, $query) = explode('?', $url);
+          }
           $css = file_get_contents(DRUPAL_ROOT . $url);
           $css = $this->minify($css);
           $css = $this->strip($css);


### PR DESCRIPTION
See:
- https://www.drupal.org/node/3101439
- https://www.drupal.org/files/issues/2019-12-16/amp-query-string-undefined-offset-3101439-2.patch